### PR TITLE
Fix race condition

### DIFF
--- a/isaac_ros_gxf_extensions/gxf_isaac_foundationpose/gxf/foundationpose/foundationpose_render.cu
+++ b/isaac_ros_gxf_extensions/gxf_isaac_foundationpose/gxf/foundationpose/foundationpose_render.cu
@@ -233,6 +233,9 @@ __global__ void pose_clip_kernel_fused(
         result = matrix_vec_mul4x4(shared_bbox, result);
 
         *transformed_matrix = result;
+
+        // Make sure all threads have read the shared memory before thread 0 writes to it in the next iteration
+        __syncthreads();
     }
 }
 


### PR DESCRIPTION
Fixes a race condition discovered by the compute sanitizer. The writer threads might enter the next loop iteration before all reader threads have read their values. Adding `__syncthreads()` to avoid this.