### PR TITLE
Fix illegal memory access for textureless meshes

### DIFF
--- a/isaac_ros_gxf_extensions/gxf_isaac_foundationpose/gxf/foundationpose/foundationpose_render.cpp
+++ b/isaac_ros_gxf_extensions/gxf_isaac_foundationpose/gxf/foundationpose/foundationpose_render.cpp
@@ -607,11 +607,12 @@ gxf_result_t FoundationposeRender::NvdiffrastRender(
     CHECK_CUDA_ERRORS(cudaGetLastError());
   } else {
     auto float_texture_map_data = float_texture_map_tensor_.exportData<nvcv::TensorDataStridedCuda>();
+    // The texture map is a list of vertex colors, needs broadcasting in interpolate to avoid illegal memory access
     interpolate(
         cuda_stream,
         reinterpret_cast<float*>(float_texture_map_data->basePtr()), rast_out_device_, mesh_data_ptr->mesh_faces_device, color_device_,
         mesh_data_ptr->num_vertices, mesh_data_ptr->num_faces, kVertexPoints,
-        H, W, N);
+        H, W, N, 1);
     CHECK_CUDA_ERRORS(cudaGetLastError());
   }
 
@@ -833,7 +834,11 @@ gxf_result_t FoundationposeRender::tick() noexcept {
   // Get mesh data from sampling component if not already set
   auto mesh_data_ptr = mesh_storage_.get()->GetMeshData();
 
-  if (float_texture_map_tensor_.empty() || texture_path_cache_ != mesh_data_ptr->texture_path) {
+  // For pure color texture (vetex colors), we can reuse the cached version if the size matches
+  if (float_texture_map_tensor_.empty() || texture_path_cache_ != mesh_data_ptr->texture_path
+      || mesh_data_ptr->texture_map_height != float_texture_map_tensor_.shape()[1]
+      || mesh_data_ptr->texture_map_width != float_texture_map_tensor_.shape()[2]
+      || mesh_data_ptr->texture_map_channels != float_texture_map_tensor_.shape()[3]) {
     NormalizeImage(
       cuda_stream_,
       mesh_data_ptr->texture_map_device, 

--- a/isaac_ros_gxf_extensions/gxf_isaac_foundationpose/gxf/foundationpose/foundationpose_render.cu
+++ b/isaac_ros_gxf_extensions/gxf_isaac_foundationpose/gxf/foundationpose/foundationpose_render.cu
@@ -330,7 +330,7 @@ void rasterize(
 
 void interpolate(
     cudaStream_t stream, float* attr_ptr, float* rast_ptr, int32_t* tri_ptr, float* out, int num_vertices,
-    int num_triangles, int attr_dim, int H, int W, int C) {
+    int num_triangles, int attr_dim, int H, int W, int C, int attr_bc) {
   int instance_mode = attr_dim > 2 ? 1 : 0;
 
   InterpolateKernelParams p = {};  // Initialize all fields to zero.
@@ -346,7 +346,7 @@ void interpolate(
   p.attr = attr_ptr;
   p.rast = rast_ptr;
   p.tri = tri_ptr;
-  p.attrBC = 0;
+  p.attrBC = attr_bc;
   p.out = out;
 
   // Choose launch parameters.

--- a/isaac_ros_gxf_extensions/gxf_isaac_foundationpose/gxf/foundationpose/foundationpose_render.cu.hpp
+++ b/isaac_ros_gxf_extensions/gxf_isaac_foundationpose/gxf/foundationpose/foundationpose_render.cu.hpp
@@ -50,7 +50,7 @@ void rasterize(
     int H, int W, int C);
 void interpolate(
     cudaStream_t stream, float* attr_ptr, float* rast_ptr, int32_t* tri_ptr, float* out, int num_vertices,
-    int num_triangles, int attr_dim, int H, int W, int C);
+    int num_triangles, int attr_dim, int H, int W, int C, int attr_bc = 0);
 void texture(
     cudaStream_t stream, float* tex_ptr, float* uv_ptr, float* out, int tex_height, int tex_width, int tex_channel,
     int tex_depth, int H, int W, int N);


### PR DESCRIPTION
Creating a dummy texture for textureless meshes the way it is done so far causes illegal memory accesses if `num_vertices * num_views > 1920 * 1080`. To avoid this, this PR allocates a vertex color array instead of a texture and uses broadcasting to correctly access the colors in the renderer.