### PR TITLE
Convert degrees to radians for inplane rotations

### DIFF
--- a/isaac_ros_gxf_extensions/gxf_isaac_foundationpose/gxf/foundationpose/foundationpose_sampling.cpp
+++ b/isaac_ros_gxf_extensions/gxf_isaac_foundationpose/gxf/foundationpose/foundationpose_sampling.cpp
@@ -444,13 +444,14 @@ std::vector<Eigen::Matrix4f> SampleViewsIcosphere(unsigned int n_views) {
 std::vector<Eigen::Matrix4f> MakeRotationGrid(const std::vector<std::string>& symmetry_axes, 
                                              const std::vector<std::string>& fixed_axis_angles, 
                                              unsigned int n_views = 40, 
-                                             int inplane_step = 60) {
+                                             double inplane_step = 60.0) {
   auto cam_in_obs = SampleViewsIcosphere(n_views);
   GXF_LOG_DEBUG("[FoundationposeSampling] %lu poses generated from icosphere", cam_in_obs.size());
 
+  inplane_step = inplane_step / 180.0 * M_PI;  // Convert degrees to radians
   std::vector<Eigen::Matrix4f> rot_grid;
   for (unsigned int i = 0; i < cam_in_obs.size(); i++) {
-    for (double inplane_rot = 0; inplane_rot < 360; inplane_rot += inplane_step) {
+    for (double inplane_rot = 0; inplane_rot < 2.0 * M_PI; inplane_rot += inplane_step) {
       Eigen::Matrix4f cam_in_ob = cam_in_obs[i];
       auto R_inplane = Eigen::Affine3f::Identity();
       R_inplane.rotate(Eigen::AngleAxisf(0, Eigen::Vector3f::UnitX()))


### PR DESCRIPTION
The numbers for creating the inplane rotations are clearly given in degrees, but the code for creating the rotation matrix expects radians. This PR adds a conversion to fix this.
This fixes https://github.com/NVIDIA-ISAAC-ROS/isaac_ros_pose_estimation/issues/73, but differs from the solution proposed in the issue by making the conversion outside of the loop for efficiency.