### PR TITLE
fix(foundationpose): fix tf_to_center sign inversion in pose decoder

### DIFF
--- a/isaac_ros_gxf_extensions/gxf_isaac_foundationpose/gxf/foundationpose/foundationpose_decoder.cpp
+++ b/isaac_ros_gxf_extensions/gxf_isaac_foundationpose/gxf/foundationpose/foundationpose_decoder.cpp
@@ -170,9 +170,10 @@ gxf_result_t FoundationposeDecoder::tick() noexcept {
       bytes_per_element, cudaMemcpyDeviceToHost, cuda_stream_));
   CHECK_CUDA_ERRORS(cudaStreamSynchronize(cuda_stream_));
   
-  // Add the distance from edge to the center because
+  // Undo mesh centering: vertices were stored as (v - center), so the
+  // API pose must map original vertices via t_api = t - R*center.
   Eigen::Matrix4f tf_to_center = Eigen::Matrix4f::Identity();
-  tf_to_center.block<3, 1>(0, 3) = mesh_data_ptr->mesh_model_center;
+  tf_to_center.block<3, 1>(0, 3) = -mesh_data_ptr->mesh_model_center;
   pose_matrix = pose_matrix * tf_to_center;
   
 


### PR DESCRIPTION
## Summary

- Fix inverted sign of `mesh_model_center` in `foundationpose_decoder.cpp` when composing `tf_to_center`
- The decoder used `+mesh_model_center` but should use `-mesh_model_center`, matching the original Python implementation (`estimater.py:get_tf_to_centered_mesh()`)
- This caused a systematic translation error of `2 * R * mesh_model_center` in the output pose

## Details

Mesh vertices are centered during loading: `v_stored = v_original - center`. The internal pose maps centered vertices to camera: `p_cam = R * (v - c) + t`. The API pose should map original vertices: `t_api = t - R*c`, requiring `tf_to_center = [I | -c]`.

The bug used `+c`, producing `t_api = t + R*c` — a `2*R*c` offset. For a mesh with bbox center ~22mm from origin, this results in ~44mm systematic translation error.

Fixes #92

## Test

Tested on QR0008 industrial part (20 scenes): translation error dropped from ~44mm to ~2mm after fix, matching the Python implementation's accuracy.